### PR TITLE
Defaults to WEBDAV_* for username and password if not provided

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+Readme.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine
 MAINTAINER ViViDboarder <ViViDboarder@gmail.com>
 
 RUN apk -Uuv add curl ca-certificates
-ADD push.sh /bin/
+COPY push.sh /bin/
 RUN chmod +x /bin/push.sh
 
 ENTRYPOINT /bin/push.sh

--- a/push.sh
+++ b/push.sh
@@ -1,7 +1,16 @@
 #! /bin/sh
 
+# Use WEBDAV_USERNAME or WEBDAV_PASSWORD as default, if provided
+if [ -z "$PLUGIN_USERNAME" ] && [ ! -z "$WEBDAV_USERNAME" ]; then
+    PLUGIN_USERNAME="$WEBDAV_USERNAME"
+fi
+if [ -z "$PLUGIN_PASSWORD" ] && [ ! -z "$WEBDAV_PASSWORD" ]; then
+    PLUGIN_PASSWORD="$WEBDAV_PASSWORD"
+fi
+
 # If username and password are provided, add auth
 if [ ! -z "$PLUGIN_USERNAME" ] && [ ! -z "$PLUGIN_PASSWORD" ]; then
     AUTH="-u ${PLUGIN_USERNAME}:${PLUGIN_PASSWORD}"
 fi
+
 curl -T $PLUGIN_FILE $AUTH $PLUGIN_DESTINATION


### PR DESCRIPTION
Verified by wrapping curl with echo and running

```
drone-webdav (master)$ bash -c "PLUGIN_DESTINATION=dest ./push.sh"
curl -T   dest
drone-webdav (master)$
bash -c "WEBDAV_USERNAME=user WEBDAV_PASSWORD=pass PLUGIN_DESTINATION=dest ./push.sh"
curl -T  -u user:pass dest
drone-webdav (master)$
bash -c "PLUGIN_USERNAME=puser WEBDAV_USERNAME=user WEBDAV_PASSWORD=pass PLUGIN_DESTINATION=dest ./push.sh"
curl -T  -u puser:pass dest
drone-webdav (master)$
bash -c "PLUGIN_USERNAME=puser PLUGIN_PASSWORD=ppass WEBDAV_USERNAME=user WEBDAV_PASSWORD=pass PLUGIN_DESTINATION=dest ./push.sh"
curl -T  -u puser:ppass dest
```