### PR TITLE
Fix user->username in Readme.md examples

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -13,7 +13,7 @@ pipeline:
     settings:
       file: com.vividboarder.otbeta/build/outputs/apk/com.vividboarder.otbeta-debug.apk
       destination: https://my.nextcloud.com/remote.php/dav/files/vividboarder/Android/Apks/
-      user: myusername
+      username: myusername
       password: mypassword
 ```
 
@@ -26,7 +26,7 @@ pipeline:
     settings:
       file: com.vividboarder.otbeta/build/outputs/apk/com.vividboarder.otbeta-debug.apk
       destination: https://my.nextcloud.com/remote.php/dav/files/vividboarder/Android/Apks/
-      user:
+      username:
         from_secret: WEBDAV_USER
       password:
         from_secret: WEBDAV_PASSWORD


### PR DESCRIPTION
Hi!

I was trying to use your plugin with Woodpecker-CI to upload some files to Nextcloud.
Unfortunately, it took me a while to understand how the `settings` in the pipeline relate to the environment variables used in `push.sh`.

The script uses `PLUGIN_USERNAME`, but the setting `user` will generate an environment variable `PLUGIN_USER` instead.

This PR should help other new users :)

Regards,
Tom