### PR TITLE
fixed PLUGIN_CUSTOM_ARGUMENTS

### DIFF
--- a/push.sh
+++ b/push.sh
@@ -30,7 +30,7 @@ fi
 
 # Additional arguments to be passed to curl.
 if [ -n "$PLUGIN_CUSTOM_ARGUMENTS" ]; then
-  ARGS+=("${PLUGIN_CUSTOM_ARGUMENTS}")
+  while read arg; do ARGS+=("$arg"); done <<(echo ${PLUGIN_CUSTOM_ARGUMENTS} | tr ' ' '\n' )
 fi
 
 # Set PLUGIN_ATTEMPTS to one if nothing else is specified

--- a/push.sh
+++ b/push.sh
@@ -28,6 +28,11 @@ if [ -n "$PLUGIN_TIMEOUT" ]; then
   ARGS+=(--max-time "${PLUGIN_TIMEOUT}")
 fi
 
+# Additional arguments to be passed to curl.
+if [ -n "$PLUGIN_CUSTOM_ARGUMENTS" ]; then
+  ARGS+=("${PLUGIN_CUSTOM_ARGUMENTS}")
+fi
+
 # Set PLUGIN_ATTEMPTS to one if nothing else is specified
 if [ -z "$PLUGIN_ATTEMPTS" ]; then
   PLUGIN_ATTEMPTS=1


### PR DESCRIPTION
Good afternoon.
i implemented the parameter `PLUGIN_CUSTOM_ARGUMENTS`. I'm surprised that it's in the documentation but it's not in the code.

I consider this option important. I am using self-signed certificates.
```yaml
  environment:
    PLUGIN_CUSTOM_ARGUMENTS: --insecure
```

now everything works as it should.