### PR TITLE
Add unquoted custom args back in

### DIFF
--- a/push.sh
+++ b/push.sh
@@ -36,8 +36,16 @@ fi
 # Repeat the upload as long as specified.
 while [ "${PLUGIN_ATTEMPTS}" -gt 0 ]; do
 
-    # Uploading the file
-    curl --fail-with-body --show-error --silent "${ARGS[@]}" --upload-file "$PLUGIN_FILE" "$PLUGIN_DESTINATION" && {
+    # Uploading the file 
+    # shellcheck disable=SC2086
+    curl \
+      $PLUGIN_CUSTOM_ARGUMENTS \
+      --fail-with-body \
+      --show-error \
+      --silent \
+      "${ARGS[@]}" \
+      --upload-file "$PLUGIN_FILE" \
+      "$PLUGIN_DESTINATION" && {
         # Terminate the script as soon as the upload is successful
     echo "[INFO] Upload was successful."
     exit 0


### PR DESCRIPTION
This requires disabling shellcheck for the whole line. I haven't yet been able to find a way to let the shell parse out args into an array with quotes.

Closes #20 